### PR TITLE
Put declarations on Includes.h to make it compatible with Arduino 1.6.5

### DIFF
--- a/CODE/NANO-Minipops/Includes.h
+++ b/CODE/NANO-Minipops/Includes.h
@@ -16,6 +16,10 @@
 
 // http://janostman.wordpress.com
 
+#ifndef Arduino_h
+  #include <Arduino.h>
+#endif
+
 
 // The value will quickly become too large for an int to store
 unsigned long previousMicros = 0; 

--- a/CODE/NANO-Minipops/NANO-Minipops.ino
+++ b/CODE/NANO-Minipops/NANO-Minipops.ino
@@ -12,7 +12,7 @@
 // NANO Modules
 //
 
-#include "includes.h"
+#include "Includes.h"
 
 #include <avr/io.h>
 #include <avr/pgmspace.h>


### PR DESCRIPTION
He solucionado el fallo que le ocurria a la gente en los talleres cuando se usaba Arduino 1.6.5. Ahora compila tanto en 1.6.5 como en 1.8.5 y posterior.